### PR TITLE
Fix Projection Example for new Plugin Changes

### DIFF
--- a/docs/src/IsoProjectionExample.js
+++ b/docs/src/IsoProjectionExample.js
@@ -11,14 +11,17 @@ class IsoProjectionExample extends Scene {
 
   preload() {
     this.load.image('cube', '../dist/assets/cube.png');
-    this.load.plugin('IsoPlugin', IsoPlugin);
+    this.load.scenePlugin({
+      key: "IsoPlugin",
+      url: IsoPlugin,
+      sceneKey: "iso"
+    });
   }
 
   create() {
-    this.sys.install('IsoPlugin');
 
     // Set the anchor of the isometric projection to the mid top of the screen
-    this.iso.projector.origin.setTo(0.5, 0.1);
+    this.iso.projector.anchor.setTo(0.5, 0.1);
 
     // Even though the children are added back to front, it is sorted the right way
     // because depth value is set on the IsoSprites and Phaser 3 sorts after that by default.


### PR DESCRIPTION
As of Phaser 3.8 the way plugins are loaded changed. This PR will fix the syntax. 
Also origin does not seem to exist only anchor. I assume that is a typo?